### PR TITLE
Fix naming conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-For releases `< 1.0.0` minor version step indicate breaking changes.
+For releases `< 1.0.0` minor version steps may indicate breaking changes too.
 
 ## [Unreleased] - YYYY-MM-DD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 For releases `< 1.0.0` minor version step indicate breaking changes.
 
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+
+- Added *debug* images with CKAN FLASK Debug Toolbar enabled, see
+  [here](https://github.com/tum-gis/ckan-docker#1234-image-versioning)
+
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Deprecated
+
+## [0.0.5] - 2023-03-30
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Deprecated
+
 ## [0.0.4] - 2023-03-02
 
 ### Changed
@@ -49,6 +80,8 @@ For releases `< 1.0.0` minor version step indicate breaking changes.
 
 ### Deprecated
 
+[Unreleased]: https://github.com/tum-gis/ckan-docker/compare/0.0.5...HEAD
+[0.0.5]: https://github.com/tum-gis/ckan-docker/compare/0.0.4...0.0.5
 [0.0.4]: https://github.com/tum-gis/ckan-docker/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/tum-gis/ckan-docker/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/tum-gis/ckan-docker/compare/0.0.1...0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,32 @@ For releases `< 1.0.0` minor version step indicate breaking changes.
 
 ## [0.0.5] - 2023-03-30
 
+**Note: This is a testing release that might contain errors. Do not use this
+for production environments.**
+
 ### Added
+
+- Added [`ckanext-dcat`](https://extensions.ckan.org/extension/dcat/)
+- Added [`ckanext-spatial`](https://github.com/ckan/ckanext-spatial)
+- Added `CKAN_INI` env var for CKAN config.ini file path for better compatibility with
+  official CKAN images
+- Set timezone using `TZ` env var
+- Allow setting runtime base image with ` BASEIMAGE_REPOSITORY` build arg
 
 ### Changed
 
+- Use official CKAN images for build stage
+- Update Update OCI specs image labels
+- Various docs updates
+
 ### Removed
 
+- Dropped outdated build scripts
+
 ### Fixed
+
+- Several smaller fixes
+- Fixed CKAN extension loading order
 
 ### Security
 


### PR DESCRIPTION
@MarijaKnezevic @TomeCirun let's use this PR for discussing the naming issue we started fixing in #14.

Here is the error msg from the logs again:

```text
Defaulted container "ckan" out of: ckan, init-data (init), pg-ready (init)
/srv/app/start_ckan.sh: Ignoring /srv/app/docker-entrypoint.d/* (not an sh or py file)

Starting UWSGI with '2' workers
[prerun] Start check_db_connection...
[prerun] Start check_solr_connection...
[prerun] Succesfully connected to solr and CKAN schema loaded
[prerun] Start init_db...
[prerun] Initializing or upgrading db - start using ckan db init
2023-04-11 06:57:23,460 INFO  [ckan.cli] Using configuration file /srv/app/production.ini
2023-04-11 06:57:23,460 INFO  [ckan.config.environment] Loading static files from public
2023-04-11 06:57:23,584 INFO  [ckan.config.environment] Loading templates from /srv/app/src/ckan/ckan/templates
2023-04-11 06:57:23,960 INFO  [ckan.config.environment] Loading templates from /srv/app/src/ckan/ckan/templates
Traceback (most recent call last):
  File "/usr/local/bin/ckan", line 8, in <module>
    sys.exit(ckan())
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 781, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 700, in make_context
    self.parse_args(ctx, args)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 115, in parse_args
    result = super(ExtendableGroup, self).parse_args(ctx, args)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1212, in parse_args
    rest = Command.parse_args(self, ctx, args)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1048, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1630, in handle_parse_result
    value = invoke_param_callback(self.callback, ctx, self, value)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 123, in invoke_param_callback
    return callback(ctx, param, value)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 125, in _init_ckan_config
    _add_ctx_object(ctx, value)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 134, in _add_ctx_object
    ctx.obj = CtxObject(path)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 56, in __init__
    self.app = make_app(self.config)
  File "/srv/app/src/ckan/ckan/config/middleware/__init__.py", line 56, in make_app
    load_environment(conf)
  File "/srv/app/src/ckan/ckan/config/environment.py", line 123, in load_environment
    p.load_all()
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 165, in load_all
    load(*plugins)
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 193, in load
    plugins_update()
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 153, in plugins_update
    environment.update_config()
  File "/srv/app/src/ckan/ckan/config/environment.py", line 322, in update_config
    logic.get_action('get_site_user')({'ignore_auth': True}, None)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 454, in get_action
    raise NameConflict(
ckan.logic.NameConflict: The action 'user_create' is already implemented in 'display_group'

Traceback (most recent call last):
  File "prerun.py", line 217, in <module>
    init_db()
  File "prerun.py", line 113, in init_db
    raise e
  File "prerun.py", line 101, in init_db
    subprocess.check_output(db_command, stderr=subprocess.STDOUT)
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ckan', '-c', '/srv/app/production.ini', 'db', 'init']' returned non-zero exit status 1.
[CKAN prerun] FAILED. Exiting...
```