### PR TITLE
CKAN security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # VScode
 .vscode/
+
+# testing folder
+/ignore

--- a/sddi-base/Dockerfile
+++ b/sddi-base/Dockerfile
@@ -218,4 +218,17 @@ RUN set -ex && \
   # Remove wheels
   rm -rf ${APP_DIR}/ext_wheels
 
+# Apply ckanext-security path #################################################
+# WIP: For testing, we copy this to all possible locations. First location should be sufficient.
+COPY --chown=ckan:ckan who.ini ${APP_DIR}/who.ini
+COPY --chown=ckan:ckan who.ini ${CKAN_DIR}/who.ini
+COPY --chown=ckan:ckan who.ini ${CKAN_DIR}/ckan/config/who.ini
+
+# Download
+# ADD https://raw.githubusercontent.com/data-govt-nz/ckanext-security/${CKANEXT_SECURITY_VERSION}/ckanext-security.patch \
+#  /tmp/sec.patch
+
+COPY --chown=ckan:ckan flask_app.py ${CKAN_DIR}/ckan/config/middleware/flask_app.py
+COPY --chown=ckan:ckan pylons_app.py ${CKAN_DIR}/ckan/config/middleware/pylons_app.py
+
 USER ckan

--- a/sddi-base/Dockerfile
+++ b/sddi-base/Dockerfile
@@ -87,6 +87,19 @@ RUN set -ex && \
   pip wheel --wheel-dir=/wheels \
     git+${CKANEXT_REPEATING_GITHUB_URL}.git@${CKANEXT_REPEATING_VERSION}#egg=ckanext-repeating
 
+# ckanext-security ############################################################
+ARG CKANEXT_SECURITY_VERSION="v3.0.4"
+ENV CKANEXT_SECURITY_VERSION=${CKANEXT_SECURITY_VERSION}
+ENV CKANEXT_SECURITY_GITHUB_URL="https://github.com/data-govt-nz/ckanext-security"
+
+RUN set -ex && \
+  pip wheel --wheel-dir=/wheels -r \
+    https://raw.githubusercontent.com/data-govt-nz/ckanext-security/${CKANEXT_SECURITY_VERSION}/requirements.txt && \
+  curl -o /wheels/ckanext-security.txt \
+    https://raw.githubusercontent.com/data-govt-nz/ckanext-security/${CKANEXT_SECURITY_VERSION}/requirements.txt && \
+  pip wheel --wheel-dir=/wheels \
+    git+${CKANEXT_SECURITY_GITHUB_URL}.git@${CKANEXT_SECURITY_VERSION}#egg=ckanext-security
+
 # ckanext-spatial #############################################################
 FROM ghcr.io/keitaroinc/ckan:${CKAN_VERSION_BUILD_SPATIAL} as extbuild-spatial
 
@@ -181,6 +194,11 @@ RUN set -ex && \
 # ckanext-repeating ###########################################################
 RUN set -ex && \
   pip install --no-index --find-links=${APP_DIR}/ext_wheels ckanext-repeating
+
+# ckanext-security ############################################################
+RUN set -ex && \
+  pip install -r ${APP_DIR}/ext_wheels/ckanext-security.txt && \
+  pip install --no-index --find-links=${APP_DIR}/ext_wheels ckanext-security
 
 # Copy init scripts and additional files
 COPY --chown=ckan:ckan initScripts/ ${APP_DIR}/docker-afterinit.d

--- a/sddi-base/Dockerfile
+++ b/sddi-base/Dockerfile
@@ -137,6 +137,7 @@ FROM ghcr.io/keitaroinc/ckan:${CKAN_VERSION_RUNTIME_STAGE} as runtime
 ENV CKAN__PLUGINS "image_view text_view recline_view datastore datapusher \
   hierarchy_display hierarchy_form display_group relation \
   spatial_metadata spatial_query datesearch repeating composite scheming_datasets \
+  security \
   envvars"
 
 # Extra env for compatibility with ckan/base Docker images for downstream k8s

--- a/sddi-base/flask_app.py
+++ b/sddi-base/flask_app.py
@@ -1,0 +1,630 @@
+# encoding: utf-8
+
+import os
+import sys
+import re
+import time
+import inspect
+import itertools
+import pkgutil
+
+from flask import Blueprint, send_from_directory
+from flask.ctx import _AppCtxGlobals
+from flask.sessions import SessionInterface
+from flask_multistatic import MultiStaticFlask
+
+import six
+from werkzeug.exceptions import default_exceptions, HTTPException
+from werkzeug.routing import Rule
+
+from flask_babel import Babel
+
+from beaker.middleware import SessionMiddleware
+from ckan.common import asbool
+from fanstatic import Fanstatic
+from repoze.who.config import WhoConfig
+from repoze.who.middleware import PluggableAuthenticationMiddleware
+
+import ckan.model as model
+from ckan.lib import base
+from ckan.lib import helpers
+from ckan.lib import jinja_extensions
+from ckan.lib import uploader
+from ckan.lib import i18n
+from ckan.common import config, g, request, ungettext
+from ckan.config.middleware.common_middleware import (TrackingMiddleware,
+                                                      HostHeaderMiddleware,
+                                                      RootPathMiddleware)
+import ckan.lib.app_globals as app_globals
+import ckan.lib.plugins as lib_plugins
+import ckan.plugins.toolkit as toolkit
+from ckan.lib.webassets_tools import get_webassets_path
+
+from ckan.plugins import PluginImplementations
+from ckan.plugins.interfaces import IBlueprint, IMiddleware, ITranslation
+from ckan.views import (identify_user,
+                        set_cors_headers_for_response,
+                        check_session_cookie,
+                        set_controller_and_action,
+                        set_cache_control_headers_for_response,
+                        handle_i18n,
+                        set_ckan_current_url,
+                        )
+
+import logging
+from logging.handlers import SMTPHandler
+log = logging.getLogger(__name__)
+
+
+class I18nMiddleware(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+
+        handle_i18n(environ)
+        return self.app(environ, start_response)
+
+
+class CKANBabel(Babel):
+    def __init__(self, *pargs, **kwargs):
+        super(CKANBabel, self).__init__(*pargs, **kwargs)
+        self._i18n_path_idx = 0
+
+    @property
+    def domain(self):
+        default = super(CKANBabel, self).domain
+        multiple = self.app.config.get('BABEL_MULTIPLE_DOMAINS')
+        if not multiple:
+            return default
+        domains = multiple.split(';')
+        try:
+            return domains[self._i18n_path_idx]
+        except IndexError:
+            return default
+
+    @property
+    def translation_directories(self):
+        self._i18n_path_idx = 0
+        for path in super(CKANBabel, self).translation_directories:
+            yield path
+            self._i18n_path_idx += 1
+
+
+class BeakerSessionInterface(SessionInterface):
+    def open_session(self, app, request):
+        if 'beaker.session' in request.environ:
+            return request.environ['beaker.session']
+
+    def save_session(self, app, session, response):
+        session.save()
+
+    def is_null_session(self, obj):
+
+        is_null = super(BeakerSessionInterface, self).is_null_session(obj)
+
+        if not is_null:
+            # Beaker always adds these keys on each request, so if these are
+            # the only keys present we assume it's an empty session
+
+            is_null = (
+                sorted(obj.keys()) in [
+                    # Beaker 0.11 (py3)
+                    [u"_accessed_time", u"_creation_time", u"_domain",
+                        u"_path"],
+                    # Beaker 0.10 (py2)
+                    [u"_accessed_time", u"_creation_time"]
+                ]
+            )
+
+        return is_null
+
+
+def make_flask_stack(conf):
+    """ This has to pass the flask app through all the same middleware that
+    Pylons used """
+
+    root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    debug = asbool(conf.get('debug', conf.get('DEBUG', False)))
+    testing = asbool(conf.get('testing', conf.get('TESTING', False)))
+    app = flask_app = CKANFlask(__name__, static_url_path='')
+
+    # Register storage for accessing group images, site logo, etc.
+    storage_folder = []
+    storage = uploader.get_storage_path()
+    if storage:
+        storage_folder = [os.path.join(storage, 'storage')]
+
+    # Static files folders (core and extensions)
+    public_folder = config.get(u'ckan.base_public_folder')
+    app.static_folder = config.get(
+        'extra_public_paths', ''
+    ).split(',') + [os.path.join(root, public_folder)] + storage_folder
+
+    app.jinja_options = jinja_extensions.get_jinja_env_options()
+    app.jinja_env.policies['ext.i18n.trimmed'] = True
+
+    app.debug = debug
+    app.testing = testing
+    app.template_folder = os.path.join(root, 'templates')
+    app.app_ctx_globals_class = CKAN_AppCtxGlobals
+    app.url_rule_class = CKAN_Rule
+
+    # Update Flask config with the CKAN values. We use the common config
+    # object as values might have been modified on `load_environment`
+    if config:
+        app.config.update(config)
+    else:
+        app.config.update(conf)
+
+    # Do all the Flask-specific stuff before adding other middlewares
+
+    # Secret key needed for flask-debug-toolbar and sessions
+    if not app.config.get('SECRET_KEY'):
+        app.config['SECRET_KEY'] = config.get('beaker.session.secret')
+    if not app.config.get('SECRET_KEY'):
+        raise RuntimeError(u'You must provide a value for the secret key'
+                           ' with the SECRET_KEY config option')
+
+    root_path = config.get('ckan.root_path', None)
+    if debug:
+        from flask_debugtoolbar import DebugToolbarExtension
+        app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
+        debug_ext = DebugToolbarExtension()
+
+        # register path that includes `ckan.site_root` before
+        # initializing debug app. In such a way, our route receives
+        # higher precedence.
+
+        # TODO: After removal of Pylons code, switch to
+        # `APPLICATION_ROOT` config value for flask application. Right
+        # now it's a bad option because we are handling both pylons
+        # and flask urls inside helpers and splitting this logic will
+        # bring us tons of headache.
+        if root_path:
+            app.add_url_rule(
+                root_path.replace('{{LANG}}', '').rstrip('/') +
+                '/_debug_toolbar/static/<path:filename>',
+                '_debug_toolbar.static', debug_ext.send_static_file
+            )
+        debug_ext.init_app(app)
+
+        from werkzeug.debug import DebuggedApplication
+        app.wsgi_app = DebuggedApplication(app.wsgi_app, True)
+
+    namespace = 'beaker.session.'
+    session_opts = {k.replace('beaker.', ''): v
+                    for k, v in six.iteritems(config)
+                    if k.startswith(namespace)}
+    if (not session_opts.get('session.data_dir') and
+            session_opts.get('session.type', 'file') == 'file'):
+        cache_dir = conf.get('cache_dir') or conf.get('cache.dir')
+        session_opts['session.data_dir'] = '{data_dir}/sessions'.format(
+            data_dir=cache_dir)
+
+    app.wsgi_app = RootPathMiddleware(app.wsgi_app, session_opts)
+    app.session_interface = BeakerSessionInterface()
+
+    # Add Jinja2 extensions and filters
+    app.jinja_env.filters['empty_and_escape'] = \
+        jinja_extensions.empty_and_escape
+
+    # Common handlers for all requests
+    app.before_request(ckan_before_request)
+    app.after_request(ckan_after_request)
+
+    # Template context processors
+    app.context_processor(helper_functions)
+    app.context_processor(c_object)
+    app.context_processor(request_object)
+
+    @app.context_processor
+    def ungettext_alias():
+        u'''
+        Provide `ungettext` as an alias of `ngettext` for backwards
+        compatibility
+        '''
+        return dict(ungettext=ungettext)
+
+    # Babel
+    _ckan_i18n_dir = i18n.get_ckan_i18n_dir()
+
+    pairs = [
+        (_ckan_i18n_dir, u'ckan')
+    ] + [
+        (p.i18n_directory(), p.i18n_domain())
+        for p in reversed(list(PluginImplementations(ITranslation)))
+    ]
+
+    i18n_dirs, i18n_domains = zip(*pairs)
+
+    app.config[u'BABEL_TRANSLATION_DIRECTORIES'] = ';'.join(i18n_dirs)
+    app.config[u'BABEL_DOMAIN'] = 'ckan'
+    app.config[u'BABEL_MULTIPLE_DOMAINS'] = ';'.join(i18n_domains)
+    app.config[u'BABEL_DEFAULT_TIMEZONE'] = str(helpers.get_display_timezone())
+
+    babel = CKANBabel(app)
+
+    babel.localeselector(get_locale)
+
+    # WebAssets
+    _setup_webassets(app)
+
+    # Auto-register all blueprints defined in the `views` folder
+    _register_core_blueprints(app)
+    _register_error_handler(app)
+
+    # Set up each IBlueprint extension as a Flask Blueprint
+    for plugin in PluginImplementations(IBlueprint):
+        if hasattr(plugin, 'get_blueprint'):
+            plugin_blueprints = plugin.get_blueprint()
+            if not isinstance(plugin_blueprints, list):
+                plugin_blueprints = [plugin_blueprints]
+            for blueprint in plugin_blueprints:
+                app.register_extension_blueprint(blueprint)
+
+    lib_plugins.register_package_blueprints(app)
+    lib_plugins.register_group_blueprints(app)
+
+    # Set flask routes in named_routes
+    # TODO: refactor whatever helper is using this to not do it
+    if 'routes.named_routes' not in config:
+        config['routes.named_routes'] = {}
+    for rule in app.url_map.iter_rules():
+        if '.' not in rule.endpoint:
+            continue
+        controller, action = rule.endpoint.split('.')
+        needed = list(rule.arguments - set(rule.defaults or {}))
+        route = {
+            rule.endpoint: {
+                'action': action,
+                'controller': controller,
+                'highlight_actions': action,
+                'needed': needed
+            }
+        }
+        config['routes.named_routes'].update(route)
+
+    # Start other middleware
+    for plugin in PluginImplementations(IMiddleware):
+        app = plugin.make_middleware(app, config)
+
+    # Fanstatic
+    fanstatic_enable_rollup = asbool(
+        conf.get('fanstatic_enable_rollup', False))
+    if debug:
+        fanstatic_config = {
+            'versioning': True,
+            'recompute_hashes': True,
+            'minified': False,
+            'bottom': True,
+            'bundle': False,
+            'rollup': fanstatic_enable_rollup,
+        }
+    else:
+        fanstatic_config = {
+            'versioning': True,
+            'recompute_hashes': False,
+            'minified': True,
+            'bottom': True,
+            'bundle': True,
+            'rollup': fanstatic_enable_rollup,
+        }
+
+    if root_path:
+        root_path = re.sub('/{{LANG}}', '', root_path)
+        fanstatic_config['base_url'] = root_path
+    app = Fanstatic(app, **fanstatic_config)
+
+    for plugin in PluginImplementations(IMiddleware):
+        try:
+            app = plugin.make_error_log_middleware(app, config)
+        except AttributeError:
+            log.critical('Middleware class {0} is missing the method'
+                         'make_error_log_middleware.'
+                         .format(plugin.__class__.__name__))
+
+    # Initialize repoze.who
+    who_parser = WhoConfig(conf['here'])
+    who_parser.parse(open(conf['who.config_file']))
+
+    app = PluggableAuthenticationMiddleware(
+        app,
+        who_parser.identifiers,
+        who_parser.authenticators,
+        who_parser.challengers,
+        who_parser.mdproviders,
+        who_parser.request_classifier,
+        who_parser.challenge_decider,
+        logging.getLogger('repoze.who'),
+        logging.WARN,  # ignored
+        who_parser.remote_user_key
+    )
+
+    # Moved as part of ckanext-security patch
+    app = SessionMiddleware(app, session_opts)
+
+    # Update the main CKAN config object with the Flask specific keys
+    # that were set here or autogenerated
+    flask_config_keys = set(flask_app.config.keys()) - set(config.keys())
+    for key in flask_config_keys:
+        config[key] = flask_app.config[key]
+
+    # Prevent the host from request to be added to the new header location.
+    app = HostHeaderMiddleware(app)
+    if six.PY3:
+        app = I18nMiddleware(app)
+
+        if asbool(config.get('ckan.tracking_enabled', 'false')):
+            app = TrackingMiddleware(app, config)
+
+    # Add a reference to the actual Flask app so it's easier to access
+    app._wsgi_app = flask_app
+
+    return app
+
+
+def get_locale():
+    u'''
+    Return the value of the `CKAN_LANG` key of the WSGI environ,
+    set by the I18nMiddleware based on the URL.
+    If no value is defined, it defaults to `ckan.locale_default` or `en`.
+    '''
+    return request.environ.get(
+        u'CKAN_LANG',
+        config.get(u'ckan.locale_default', u'en'))
+
+
+def ckan_before_request():
+    u'''
+    Common handler executed before all Flask requests
+
+    If a response is returned by any of the functions called (
+    currently ``identify_user()` only) any further processing of the
+    request will be stopped and that response will be returned.
+
+    '''
+    response = None
+
+    g.__timer = time.time()
+
+    # Update app_globals
+    app_globals.app_globals._check_uptodate()
+
+    # Identify the user from the repoze cookie or the API header
+    # Sets g.user and g.userobj
+    response = identify_user()
+
+    # Provide g.controller and g.action for backward compatibility
+    # with extensions
+    set_controller_and_action()
+
+    set_ckan_current_url(request.environ)
+
+    return response
+
+
+def ckan_after_request(response):
+    u'''Common handler executed after all Flask requests'''
+
+    # Dispose of the SQLALchemy session
+    model.Session.remove()
+
+    # Check session cookie
+    response = check_session_cookie(response)
+
+    # Set CORS headers if necessary
+    response = set_cors_headers_for_response(response)
+
+    # Set Cache Control headers
+    response = set_cache_control_headers_for_response(response)
+
+    r_time = time.time() - g.__timer
+    url = request.environ['PATH_INFO']
+    status_code = response.status_code
+
+    log.info(' %s %s render time %.3f seconds' % (status_code, url, r_time))
+
+    return response
+
+
+def helper_functions():
+    u'''Make helper functions (`h`) available to Flask templates'''
+    if not helpers.helper_functions:
+        helpers.load_plugin_helpers()
+    return dict(h=helpers.helper_functions)
+
+
+def c_object():
+    u'''
+    Expose `c` as an alias of `g` in templates for backwards compatibility
+    '''
+    return dict(c=g)
+
+
+def request_object():
+    u"""Use CKANRequest object implicitly in templates"""
+    return dict(request=request)
+
+
+class CKAN_Rule(Rule):
+
+    u'''Custom Flask url_rule_class.
+
+    We use it to be able to flag routes defined in extensions as such
+    '''
+
+    def __init__(self, *args, **kwargs):
+        self.ckan_core = True
+        super(CKAN_Rule, self).__init__(*args, **kwargs)
+
+
+class CKAN_AppCtxGlobals(_AppCtxGlobals):
+
+    '''Custom Flask AppCtxGlobal class (flask.g).'''
+
+    def __getattr__(self, name):
+        '''
+        If flask.g doesn't have attribute `name`, fall back to CKAN's
+        app_globals object.
+        If the key is also not found in there, an AttributeError will be raised
+        '''
+        return getattr(app_globals.app_globals, name)
+
+
+class CKANFlask(MultiStaticFlask):
+
+    '''Extend the Flask class with a special method called on incoming
+     requests by AskAppDispatcherMiddleware.
+    '''
+
+    app_name = 'flask_app'
+
+    def can_handle_request(self, environ):
+        '''
+        Decides whether it can handle a request with the Flask app by
+        matching the request environ against the route mapper
+
+        Returns (True, 'flask_app', origin) if this is the case.
+
+        `origin` can be either 'core' or 'extension' depending on where
+        the route was defined.
+        '''
+        urls = self.url_map.bind_to_environ(environ)
+
+        try:
+            rule, args = urls.match(return_rule=True)
+            origin = 'core'
+            if hasattr(rule, 'ckan_core') and not rule.ckan_core:
+                origin = 'extension'
+            log.debug('Flask route match, endpoint: {0}, args: {1}, '
+                      'origin: {2}'.format(rule.endpoint, args, origin))
+
+            # Disable built-in flask's ability to prepend site root to
+            # generated url, as we are going to use locale and existing
+            # logic is not flexible enough for this purpose
+            environ['SCRIPT_NAME'] = ''
+
+            return (True, self.app_name, origin)
+        except HTTPException:
+            return (False, self.app_name)
+
+    def register_extension_blueprint(self, blueprint, **kwargs):
+        '''
+        This method should be used to register blueprints that come from
+        extensions, so there's an opportunity to add extension-specific
+        options.
+
+        Sets the rule property `ckan_core` to False, to indicate that the rule
+        applies to an extension route.
+        '''
+        self.register_blueprint(blueprint, **kwargs)
+
+        # Get the new blueprint rules
+        bp_rules = itertools.chain.from_iterable(
+            v for k, v in six.iteritems(self.url_map._rules_by_endpoint)
+            if k.startswith(u'{0}.'.format(blueprint.name))
+        )
+
+        # This compare key will ensure the rule will be near the top.
+        top_compare_key = False, -100, [(-2, 0)]
+        for r in bp_rules:
+            r.ckan_core = False
+            r.match_compare_key = lambda: top_compare_key
+
+
+def _register_core_blueprints(app):
+    u'''Register all blueprints defined in the `views` folder
+    '''
+    def is_blueprint(mm):
+        return isinstance(mm, Blueprint) and getattr(mm, 'auto_register', True)
+
+    path = os.path.join(os.path.dirname(__file__), '..', '..', 'views')
+
+    for loader, name, _ in pkgutil.iter_modules([path], 'ckan.views.'):
+        module = loader.find_module(name).load_module(name)
+        for blueprint in inspect.getmembers(module, is_blueprint):
+            app.register_blueprint(blueprint[1])
+            log.debug(u'Registered core blueprint: {0!r}'.format(blueprint[0]))
+
+
+def _register_error_handler(app):
+    u'''Register error handler'''
+
+    def error_handler(e):
+        debug = asbool(config.get('debug', config.get('DEBUG', False)))
+        if isinstance(e, HTTPException):
+            log.debug(e, exc_info=sys.exc_info) if debug else log.info(e)
+            extra_vars = {
+                u'code': e.code,
+                u'content': e.description,
+                u'name': e.name
+            }
+
+            return base.render(
+                u'error_document_template.html', extra_vars), e.code
+        log.error(e, exc_info=sys.exc_info)
+        extra_vars = {u'code': [500], u'content': u'Internal server error'}
+        return base.render(u'error_document_template.html', extra_vars), 500
+
+    for code in default_exceptions:
+        app.register_error_handler(code, error_handler)
+    if not app.debug and not app.testing:
+        app.register_error_handler(Exception, error_handler)
+        if config.get('email_to'):
+            _setup_error_mail_handler(app)
+
+
+def _setup_error_mail_handler(app):
+
+    class ContextualFilter(logging.Filter):
+        def filter(self, log_record):
+            log_record.url = request.path
+            log_record.method = request.method
+            log_record.ip = request.environ.get("REMOTE_ADDR")
+            log_record.headers = request.headers
+            return True
+
+    smtp_server = config.get('smtp.server', 'localhost')
+    mailhost = tuple(smtp_server.split(':')) \
+        if ':' in smtp_server else smtp_server
+    credentials = None
+    if config.get('smtp.user'):
+        credentials = (config.get('smtp.user'), config.get('smtp.password'))
+    secure = () if asbool(config.get('smtp.starttls')) else None
+    mail_handler = SMTPHandler(
+        mailhost=mailhost,
+        fromaddr=config.get('error_email_from'),
+        toaddrs=[config.get('email_to')],
+        subject='Application Error',
+        credentials=credentials,
+        secure=secure
+    )
+
+    mail_handler.setLevel(logging.ERROR)
+    mail_handler.setFormatter(logging.Formatter('''
+Time:               %(asctime)s
+URL:                %(url)s
+Method:             %(method)s
+IP:                 %(ip)s
+Headers:            %(headers)s
+
+'''))
+
+    context_provider = ContextualFilter()
+    app.logger.addFilter(context_provider)
+    app.logger.addHandler(mail_handler)
+
+
+def _setup_webassets(app):
+    app.use_x_sendfile = toolkit.asbool(
+        config.get('ckan.webassets.use_x_sendfile')
+    )
+
+    webassets_folder = get_webassets_path()
+
+    @app.route('/webassets/<path:path>', endpoint='webassets.index')
+    def webassets(path):
+        return send_from_directory(webassets_folder, path)

--- a/sddi-base/flask_app.py
+++ b/sddi-base/flask_app.py
@@ -204,7 +204,6 @@ def make_flask_stack(conf):
         session_opts['session.data_dir'] = '{data_dir}/sessions'.format(
             data_dir=cache_dir)
 
-    app.wsgi_app = RootPathMiddleware(app.wsgi_app, session_opts)
     app.session_interface = BeakerSessionInterface()
 
     # Add Jinja2 extensions and filters

--- a/sddi-base/initScripts/02_ckanext-security.sh
+++ b/sddi-base/initScripts/02_ckanext-security.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Migrate ckanext-security DB ..."
+ckan -c "${CKAN_INI}" security migrate
+echo "Migrate ckanext-security DB ...done!"

--- a/sddi-base/pylons_app.py
+++ b/sddi-base/pylons_app.py
@@ -1,0 +1,291 @@
+# encoding: utf-8
+
+import os
+import re
+
+from pylons.wsgiapp import PylonsApp
+
+from beaker.middleware import CacheMiddleware, SessionMiddleware
+from paste.cascade import Cascade
+from paste.registry import RegistryManager
+from paste.urlparser import StaticURLParser
+from ckan.common import asbool
+from paste.fileapp import _FileIter
+from pylons.middleware import ErrorHandler, StatusCodeRedirect
+from routes.middleware import RoutesMiddleware
+from repoze.who.config import WhoConfig
+from repoze.who.middleware import PluggableAuthenticationMiddleware
+from fanstatic import Fanstatic
+
+from ckan.plugins import PluginImplementations
+from ckan.plugins.interfaces import IMiddleware
+import ckan.lib.uploader as uploader
+from ckan.config.middleware import common_middleware
+from ckan.common import config
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def make_pylons_stack(conf, full_stack=True, static_files=True,
+                      **app_conf):
+    """Create a Pylons WSGI application and return it
+
+    ``conf``
+        The inherited configuration for this application. Normally from
+        the [DEFAULT] section of the Paste ini file.
+
+    ``full_stack``
+        Whether this application provides a full WSGI stack (by default,
+        meaning it handles its own exceptions and errors). Disable
+        full_stack when this application is "managed" by another WSGI
+        middleware.
+
+    ``static_files``
+        Whether this application serves its own static files; disable
+        when another web server is responsible for serving them.
+
+    ``app_conf``
+        The application's local configuration. Normally specified in
+        the [app:<name>] section of the Paste ini file (where <name>
+        defaults to main).
+
+    """
+    # The Pylons WSGI app
+    app = pylons_app = CKANPylonsApp()
+
+    for plugin in PluginImplementations(IMiddleware):
+        app = plugin.make_middleware(app, config)
+
+    app = common_middleware.CloseWSGIInputMiddleware(app, config)
+    app = common_middleware.RootPathMiddleware(app, config)
+    # Routing/Session/Cache Middleware
+    app = RoutesMiddleware(app, config['routes.map'])
+    # we want to be able to retrieve the routes middleware to be able to update
+    # the mapper.  We store it in the pylons config to allow this.
+    config['routes.middleware'] = app
+    app = CacheMiddleware(app, config)
+
+    # CUSTOM MIDDLEWARE HERE (filtered by error handling middlewares)
+    # app = QueueLogMiddleware(app)
+    if asbool(config.get('ckan.use_pylons_response_cleanup_middleware',
+                         True)):
+        app = execute_on_completion(app, config,
+                                    cleanup_pylons_response_string)
+
+    # Fanstatic
+    fanstatic_enable_rollup = asbool(
+        conf.get('fanstatic_enable_rollup', False))
+    if asbool(config.get('debug', False)):
+        fanstatic_config = {
+            'versioning': True,
+            'recompute_hashes': True,
+            'minified': False,
+            'bottom': True,
+            'bundle': False,
+            'rollup': fanstatic_enable_rollup,
+        }
+    else:
+        fanstatic_config = {
+            'versioning': True,
+            'recompute_hashes': False,
+            'minified': True,
+            'bottom': True,
+            'bundle': True,
+            'rollup': fanstatic_enable_rollup,
+        }
+    root_path = config.get('ckan.root_path', None)
+    if root_path:
+        root_path = re.sub('/{{LANG}}', '', root_path)
+        fanstatic_config['base_url'] = root_path
+    app = Fanstatic(app, **fanstatic_config)
+
+    for plugin in PluginImplementations(IMiddleware):
+        try:
+            app = plugin.make_error_log_middleware(app, config)
+        except AttributeError:
+            log.critical('Middleware class {0} is missing the method'
+                         'make_error_log_middleware.'
+                         .format(plugin.__class__.__name__))
+
+    if asbool(full_stack):
+        # Handle Python exceptions
+        app = ErrorHandler(app, conf, **config['pylons.errorware'])
+
+        # Display error documents for 400, 403, 404 status codes (and
+        # 500 when debug is disabled)
+        if asbool(config['debug']):
+            app = StatusCodeRedirect(app, [400, 403, 404])
+        else:
+            app = StatusCodeRedirect(app, [400, 403, 404, 500])
+
+    # Initialize repoze.who
+    who_parser = WhoConfig(conf['here'])
+    who_parser.parse(open(conf['who.config_file']))
+
+    app = PluggableAuthenticationMiddleware(
+        app,
+        who_parser.identifiers,
+        who_parser.authenticators,
+        who_parser.challengers,
+        who_parser.mdproviders,
+        who_parser.request_classifier,
+        who_parser.challenge_decider,
+        logging.getLogger('repoze.who'),
+        logging.WARN,  # ignored
+        who_parser.remote_user_key
+    )
+
+    # Moved as part of ckanext-security patch
+    app = SessionMiddleware(app, config)
+
+    # Establish the Registry for this application
+    app = RegistryManager(app, streaming=False)
+
+    if asbool(static_files):
+        # Serve static files
+        static_max_age = None if not asbool(
+            config.get('ckan.cache_enabled')) \
+            else int(config.get('ckan.static_max_age', 3600))
+
+        static_app = StaticURLParser(
+            config['pylons.paths']['static_files'],
+            cache_max_age=static_max_age)
+        static_parsers = [static_app, app]
+
+        storage_directory = uploader.get_storage_path()
+        if storage_directory:
+            path = os.path.join(storage_directory, 'storage')
+            try:
+                os.makedirs(path)
+            except OSError as e:
+                # errno 17 is file already exists
+                if e.errno != 17:
+                    raise
+
+            storage_app = StaticURLParser(path, cache_max_age=static_max_age)
+            static_parsers.insert(0, storage_app)
+
+        # Configurable extra static file paths
+        extra_static_parsers = []
+        for public_path in config.get(
+                'extra_public_paths', '').split(','):
+            if public_path.strip():
+                extra_static_parsers.append(
+                    StaticURLParser(public_path.strip(),
+                                    cache_max_age=static_max_age)
+                )
+        app = Cascade(extra_static_parsers + static_parsers)
+
+    # Prevent the host from request to be added to the new header location.
+    app = common_middleware.HostHeaderMiddleware(app)
+    # Tracking
+    if asbool(config.get('ckan.tracking_enabled', 'false')):
+        app = common_middleware.TrackingMiddleware(app, config)
+
+    # Add a reference to the actual Pylons app so it's easier to access
+    app._wsgi_app = pylons_app
+
+    return app
+
+
+class CKANPylonsApp(PylonsApp):
+
+    app_name = 'pylons_app'
+
+    def can_handle_request(self, environ):
+        '''
+        Decides whether it can handle a request with the Pylons app by
+        matching the request environ against the route mapper
+
+        Returns (True, 'pylons_app', origin) if this is the case.
+
+        origin can be either 'core' or 'extension' depending on where
+        the route was defined.
+
+        NOTE: There is currently a catch all route for GET requests to
+        point arbitrary urls to templates with the same name:
+
+            map.connect('/*url', controller='template', action='view')
+
+        This means that this function will match all GET requests. This
+        does not cause issues as the Pylons core routes are the last to
+        take precedence so the current behaviour is kept, but it's worth
+        keeping in mind.
+        '''
+
+        pylons_mapper = config['routes.map']
+        match_route = pylons_mapper.routematch(environ=environ)
+        if match_route:
+            match, route = match_route
+            origin = 'core'
+            if hasattr(route, '_ckan_core') and not route._ckan_core:
+                origin = 'extension'
+            log.debug('Pylons route match: {0} Origin: {1}'.format(
+                match, origin))
+            return (True, self.app_name, origin)
+        else:
+            return (False, self.app_name)
+
+
+class CloseCallbackWrapper(object):
+    def __init__(self, iterable, callback, environ):
+        # pylons.fileapp expects app_iter to have `file` attribute.
+        self.file = iterable
+        self.callback = callback
+        self.environ = environ
+
+    def __iter__(self):
+        """
+        return a generator that passes through items from iterable
+        then calls callback(environ).
+        """
+        try:
+            for item in self.file:
+                yield item
+        except GeneratorExit:
+            if hasattr(self.file, 'close'):
+                self.file.close()
+            raise
+        finally:
+            self.callback(self.environ)
+
+
+class FileIterWrapper(CloseCallbackWrapper, _FileIter):
+    """Same CloseCallbackWrapper, just with _FileIter mixin.
+
+    That will prevent pylons from converting file responses into
+    in-memori lists.
+    """
+    pass
+
+
+def execute_on_completion(application, config, callback):
+    """
+    Call callback(environ) once complete response is sent
+    """
+
+    def inner(environ, start_response):
+        try:
+            result = application(environ, start_response)
+        except Exception:
+            callback(environ)
+            raise
+        # paste.fileapp converts non-file responses into list
+        # In order to avoid interception of OOM Killer
+        # file responses wrapped into generator with
+        # _FileIter in parent tree.
+        klass = CloseCallbackWrapper
+        if isinstance(result, _FileIter):
+            klass = FileIterWrapper
+        return klass(result, callback, environ)
+
+    return inner
+
+
+def cleanup_pylons_response_string(environ):
+    try:
+        msg = 'response cleared by pylons response cleanup middleware'
+        environ['pylons.controller']._py_object.response._body = msg
+    except (KeyError, AttributeError):
+        pass

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -27,14 +27,11 @@ rememberer_name = use_beaker
 plugins =
     friendlyform;browser
     use_beaker
-    auth_tkt
 
 [authenticators]
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
-    auth_tkt
-    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -34,6 +34,7 @@ plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
     auth_tkt
+    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -13,10 +13,6 @@ post_logout_url = /user/logged_out
 charset = utf-8
 rememberer_name = use_beaker
 
-[general]
-request_classifier = repoze.who.classifiers:default_request_classifier
-challenge_decider = repoze.who.classifiers:default_challenge_decider
-
 [identifiers]
 plugins =
     friendlyform;browser
@@ -26,7 +22,3 @@ plugins =
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
-
-[challengers]
-plugins =
-    friendlyform;browser

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -8,10 +8,10 @@ use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
 login_handler_path = /login_generic
 logout_handler_path = /user/logout
-rememberer_name = use_beaker
 post_login_url = /user/logged_in
 post_logout_url = /user/logged_out
 charset = utf-8
+rememberer_name = use_beaker
 
 [general]
 request_classifier = repoze.who.classifiers:default_request_classifier

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -32,6 +32,7 @@ plugins =
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
+    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -12,7 +12,6 @@ use = ckan.lib.repoze_plugins.auth_tkt:make_plugin
 request_classifier = repoze.who.classifiers:default_request_classifier
 challenge_decider = repoze.who.classifiers:default_challenge_decider
 
-
 [plugin:friendlyform]
 use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
@@ -32,7 +31,6 @@ plugins =
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
-    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -6,6 +6,8 @@ delete_on_logout = True
 [plugin:friendlyform]
 use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
 rememberer_name = use_beaker
 post_login_url = /user/logged_in
 post_logout_url = /user/logged_out

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -6,8 +6,6 @@ delete_on_logout = True
 [plugin:friendlyform]
 use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
-login_handler_path = /login_generic
-logout_handler_path = /user/logout
 rememberer_name = use_beaker
 post_login_url = /user/logged_in
 post_logout_url = /user/logged_out

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -31,8 +31,6 @@ plugins =
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
-    auth_tkt
-    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -1,0 +1,32 @@
+[plugin:use_beaker]
+use = repoze.who.plugins.use_beaker:make_plugin
+key_name = ckan_session
+delete_on_logout = True
+
+[plugin:friendlyform]
+use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
+login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
+rememberer_name = use_beaker
+post_login_url = /user/logged_in
+post_logout_url = /user/logged_out
+charset = utf-8
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
+
+[identifiers]
+plugins =
+    friendlyform;browser
+    use_beaker
+
+[authenticators]
+plugins =
+    ckanext.security.authenticator:CKANLoginThrottle
+    ckanext.security.authenticator:BeakerRedisAuth
+
+[challengers]
+plugins =
+    friendlyform;browser

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -8,29 +8,30 @@ use = ckan.lib.repoze_plugins.auth_tkt:make_plugin
 # If no secret key is defined here, beaker.session.secret will be used
 #secret = somesecret
 
-[general]
-request_classifier = repoze.who.classifiers:default_request_classifier
-challenge_decider = repoze.who.classifiers:default_challenge_decider
-
 [plugin:friendlyform]
 use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
 login_handler_path = /login_generic
 logout_handler_path = /user/logout
+rememberer_name = auth_tkt
 post_login_url = /user/logged_in
 post_logout_url = /user/logged_out
 charset = utf-8
-rememberer_name = use_beaker
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
 
 [identifiers]
 plugins =
     friendlyform;browser
-    use_beaker
+    auth_tkt
 
 [authenticators]
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
-    ckanext.security.authenticator:BeakerRedisAuth
+    auth_tkt
+    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -13,7 +13,7 @@ use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
 login_handler_path = /login_generic
 logout_handler_path = /user/logout
-rememberer_name = auth_tkt
+rememberer_name = use_beaker
 post_login_url = /user/logged_in
 post_logout_url = /user/logged_out
 charset = utf-8
@@ -25,11 +25,12 @@ challenge_decider = repoze.who.classifiers:default_challenge_decider
 [identifiers]
 plugins =
     friendlyform;browser
-    auth_tkt
+    use_beaker
 
 [authenticators]
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
+    ckanext.security.authenticator:BeakerRedisAuth
     auth_tkt
     ckan.lib.authenticator:UsernamePasswordAuthenticator
 

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -26,11 +26,14 @@ challenge_decider = repoze.who.classifiers:default_challenge_decider
 plugins =
     friendlyform;browser
     use_beaker
+    auth_tkt
 
 [authenticators]
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
+    auth_tkt
+    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -3,6 +3,16 @@ use = repoze.who.plugins.use_beaker:make_plugin
 key_name = ckan_session
 delete_on_logout = True
 
+[plugin:auth_tkt]
+use = ckan.lib.repoze_plugins.auth_tkt:make_plugin
+# If no secret key is defined here, beaker.session.secret will be used
+#secret = somesecret
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
+
+
 [plugin:friendlyform]
 use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
 login_form_url= /user/login
@@ -22,3 +32,7 @@ plugins =
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
+
+[challengers]
+plugins =
+    friendlyform;browser

--- a/sddi-base/who.ini
+++ b/sddi-base/who.ini
@@ -27,11 +27,13 @@ rememberer_name = use_beaker
 plugins =
     friendlyform;browser
     use_beaker
+    auth_tkt
 
 [authenticators]
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
     ckanext.security.authenticator:BeakerRedisAuth
+    auth_tkt
 
 [challengers]
 plugins =

--- a/sddi-social/Dockerfile
+++ b/sddi-social/Dockerfile
@@ -31,7 +31,7 @@ ENV CKAN__PLUGINS "image_view text_view recline_view datastore datapusher \
   spatial_metadata spatial_query datesearch repeating composite scheming_datasets \
   resource_proxy geo_view geojson_view wmts_view shp_view \
   dcat dcat_json_interface structured_data \
-  restricted \
+  restricted security \
   disqus \
   envvars"
 

--- a/sddi/Dockerfile
+++ b/sddi/Dockerfile
@@ -57,7 +57,7 @@ ENV CKAN__PLUGINS "image_view text_view recline_view datastore datapusher \
   spatial_metadata spatial_query datesearch repeating composite scheming_datasets \
   resource_proxy geo_view geojson_view wmts_view shp_view \
   dcat dcat_json_interface structured_data \
-  restricted \
+  restricted security \
   envvars"
 
 # Copy python wheels from build stage


### PR DESCRIPTION
## ToDos, questions, notes

- Add and test [`ckanext-security`](https://github.com/data-govt-nz/ckanext-security)
  - [ ] Can't get this running so far, see here: https://github.com/data-govt-nz/ckanext-security/issues/63 
  - Test if 2FA can be disabled?
  - Adapt settings for sessions
  - Will this require https://github.com/qld-gov-au/ckanext-csrf-filter to be installed too?

## Alternative approaches

  - Use an external identity provider, to mitigate using `ckanext-security`. This requires integration of an auth standard like OAUTH2/SAML/LDAP
  - This would solve L5, L6

### Existing extensions

- https://github.com/conwetlab/ckanext-oauth2 (probably outdated)
- https://github.com/NaturalHistoryMuseum/ckanext-ldap
- https://github.com/keitaroinc/ckanext-saml2auth
- https://github.com/salsadigitalauorg/ckanext-fortify
- https://github.com/keitaroinc/ckanext-password-policy

## Overview issues PenTest

- [x] **2.1 - mandatory**: Massenmailversand: Über die "Passwort vergessen?"-Funktion ist der massenhafte Versand von
  E-Mails möglich. Hierfür benötigt man nur einen gültigen Benutzernamen, der unauthentifiziert über
  https://sddi-katalog.bayern/user/ ermittelt werden kann (siehe Schwachstelle L4). So war es möglich
  50 Mails innerhalb weniger Sekunden zu generieren.
  - Needs more research
  - Is this resolved/will be accepted, if **L4** is solved?
  - Is the feature described [here](https://github.com/data-govt-nz/ckanext-security#what-am-i) an acceptable solution?
    - *When users try to reset a password for an email address, CKAN will no longer disclose whether or not that email address exists in the DB.*
    - it should be possible to set how many emails can be sent per minute in CKAN. In official CKAN Documentation ([here](https://docs.ckan.org/en/2.9/maintaining/email-notifications.html) and [here](https://docs.ckan.org/en/2.9/maintaining/configuration.html#ckan-activity-streams-email-notifications)) it is possible to find how to set a limit on the number of emails that can be sent. But it is necessary to check how to limit e-mails for specific request.
      - @MarijaKnezevic Are you sure about this? I doubt that the password reset eMails are subject of the activity stream options. Can you test this?   

- [x] **2.2 - mandatory**: Veraltete Software mit bekannten Schwachstellen: @MarijaKnezevic bitte alle Dependencies aktualisieren
  - `moments.js`: Die Webanwendung setzt unter https://sddi-katalog.bayern/webassets/webassets-external/76307a4b018a3e05af9d08e07dcf9176_moment.js vermutlich die Version 2.1.0 der Bibliothek moment.js ein. Für diese existieren bekannte Schwachstellen: https://security.snyk.io/package/npm/moment/2.1.0 Ob die Anwendung tatsächlich für die genannten 
  Schwachstellen anfällig ist konnte im gegebenen
  Zeitrahmen und im Blackbox-Verfahren nicht ermittelt werden.
    - This is part of [ckanext-datesearch](https://github.com/MarijaKnezevic/ckanext-datesearch).
    - Should not be too hard to update this.
    - See tum-gis/ckanext-datesearch#1
  - `jQuery`: Auf Seiten mit Datensatz-Verknüpfungen – etwa /dataset/relationship/pentest-1 – wird jQuery in Version 2.0.3
von der URL https://code.jquery.com/jquery-2.0.3.min.js eingebunden.
  - `dagre.js`: 
  - `cytoscape.js`:

- [x] **2.3 - mandatory**: Fehlender Virenscan bei Dateiupload: Es war möglich eine Testvirus-Datei in die Webanwendung
hochzuladen. Dies deutet darauf hin, dass der in der Richtlinie BayITSiR-14 geforderte Virenscan
beim Upload von Dateien nicht implementiert ist.
  - Needs more research.
  - Currently, no simple solution found.
  - Can this maybe be resolved through some kind of policy, e.g. tutorial/guidelines for all people that may upload files on how to virus scan them up front?
  - **This is probably the most critical issue.** It will require significant implementation work, possibly additional maintenance...
  - Is it sufficient/acceptable, to disallow e.g. executable files for upload? See [this feature](https://github.com/data-govt-nz/ckanext-security#resource-uploadlinking-file-type-blacklist).
  - If we need to implement this:
    - Open Source Anti Virus with API + Docker: https://hub.docker.com/r/ajilaag/clamav-rest
    - More inspiration: https://github.com/sbilly/awesome-security#anti-virus--anti-malware
  - CalmAV CKAN extension (experimental): https://github.com/mutantsan/ckanext-clamav
    - This has been tested by @BWibo: This generally works, but only for VERY small files (<< 1Mb). Otherwise, there are timeouts. This needs further testing. Currently, this is not a useable solutions. Timeout are not catched, the user would face an error message.
    - for uploading files >10MB check this issue: https://github.com/UKHomeOffice/docker-clamav/issues/22 
  - Overview article on virus scanning of uploaded files: https://riskledger.com/blog/how-we-approach-virus-scanning-uploaded-files
    - Limiting file types is already supported by [`ckanext-security`](https://github.com/data-govt-nz/ckanext-security)
  - CKAN Background jobs: https://docs.ckan.org/en/2.9/maintaining/background-tasks.html
  - this can be helpful too: https://betatim.github.io/posts/clamav-memory-usage/
  - Could potentially be used for virus scanning.
  - Test Virus files: https://www.eicar.org/download-anti-malware-testfile/
  
- [x] **2.4 - mandatory**: User Enumeration: Unter https://sddi-katalog.bayern/user/ kann unauthentifizert eine Liste
aller existierender Benutzer abgerufen werden. Diese beinhaltet auch administrative Accounts.
  - Can be resolved by settings [`ckan.auth.public_user_details = False`](https://docs.ckan.org/en/2.9/maintaining/configuration.html#ckan-auth-public-user-details).
  - Fixed in https://github.com/tum-gis/sddi-ckan-k8s/commit/016da8568e272a4e0caf0fb2608f294b353bea30

- [x] **2.5 - mandatory**: Schwache Kennwortrichtlinie: Die derzeit aktive Kennwortrichtlinie fordert lediglich eine
Mindestlänge von 8 Zeichen. So sind zum Beispiel triviale Passwörter wie "12345678" möglich. Hier
sollten mindestens noch weitere Zeichengruppen (Groß- und Kleinbuchstaben oder Sonderzeichen) durch
die Kennwortrichtlinie gefordert werden.
  - Resolved, if [`ckanext-security`](https://github.com/data-govt-nz/ckanext-security) works.
  - Possibly, there are alternative solutions, e.g. config options.
  - Resolved, if [ckanext-password-policy](https://github.com/keitaroinc/ckanext-password-policy) works.
     - tum-gis/ckan-docker#46
  - This extension is probably not sufficient, as it only allows to force a password length. [ckanext-fortify](https://github.com/salsadigitalauorg/ckanext-fortify)

- [x] **2.6 - mandatory**: Brute Force auf Login möglich: Die Anwendung hat keine Schutzmaßnahmen gegen
Brute-Force-Angriffe auf die Login-Funktion. Es wurden innerhalb weniger Sekunden 50 Anmeldeversuche
mit falschem Passwort durchgeführt. Danach war der Login mit korrektem Kenntwort möglich. Zur
Behebung der Schwachstelle sollten weitere Loginversuche nach einem fehlgeschlagenen Anmeldeversuch
erst mit immer weiter steigender Verzögerung möglich sein.
  - Resolved, if [ckanext-password-policy](https://github.com/keitaroinc/ckanext-password-policy) works.
     - tum-gis/ckan-docker#46
  - Resolved, if [`ckanext-security`](https://github.com/data-govt-nz/ckanext-security) works.
- [x] **2.7 - mandatory**: Cross-Site-Scripting: Bei den Datensätzen ist das Formularfeld "Beschreibung" und bei den Organisationen das Feld "Name" anfällig für Cross-Site-Scripting. In beiden Fällen wurde die Payload `<script>alert("XSS");</script>` eingefügt und der hinterlegte Javascript-Code anschließend ausgeführt. Beim Namensfeld einer Organisation erfolgt die Ausführung jedoch nur auf der Hauptseite in der Liste der Organisationen. Auf der Detailseite der Organisation wurden die Eingaben korrekt behandelt und es kam nicht zu einer Ausführung.
  - How is sanitizing of user input fields handed in CKAN in general? Are there tools/practices in place that take care of this? 
  - Is this coming from our own implementation, e.g. in [tum-gis/ckanext-grouphierarchy-sddi](https://github.com/tum-gis/ckanext-grouphierarchy-sddi)? If yes, what do we do different with here compared to other user input fields?
  - @MarijaKnezevic, @TomeCirun: Please check if user input in the `name` field for *Organizations* and the `description` field of *Datasets* is properly sanitized regarding XSS vulnerabilities. Please check if example code like this `<script>alert("XSS");</script>` is executable through user input, or not. This affects all extension that we maintain, that parse user input in some way.
  - Is this an upstream issue?
  - Are there other user inputs that could be affected?
  -  Cross-Site-Scripting is solved in [CKAN 2.10.1](https://docs.ckan.org/en/2.10/changelog.html#v-2-10-1-2023-05-24). The documentation about Cross-Site Request Forgery (CSRF) in the extension best practices is possible to find [here](https://docs.ckan.org/en/2.10/extensions/best-practices.html#csrf-best-practices)
 
- [x] **2.8 - informative**: Browser password storage is allowed
  - Solved with removing "rember me" button [here](https://github.com/tum-gis/ckanext-grouphierarchy-sddi/commit/c48bc1c104674547f83ac11130b6341adffd1d7d)
- [x] **2.9 - recommended**: Unsafe cookie configuration
  - Should be resolved by tum-gis/sddi-ckan-k8s#22
  -  Adding custom response headers and customize cookie settings is known CKAN Issue: [issues/7060](https://github.com/ckan/ckan/issues/7060) and [issues/7060](https://github.com/ckan/ckan/issues/7060)
- [x] **2.10 - urgent**: Missing headers
  - Should be resolved by tum-gis/sddi-ckan-k8s#22
- [x] **2.11 - urgent**: No session timeout
  - Should be resolved by `who.timeout = 3600` https://docs.ckan.org/en/2.9/maintaining/configuration.html#who-timeout
  - Should be resolved by tum-gis/sddi-ckan-k8s#22
    - Not sure, if this is going to be able for the `auth_tkt` cookie

- [x] **2.12 - recommended**: Javascript from external sources