### PR TITLE
Build "latest" image for pr

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,13 +43,16 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev
           tags: |
+            # Latest tag for PR, PR number only
+            type=ref,event=pr,prefix=sddi-base-pr-
+            # Tag for with commit sha appended
             type=ref,event=pr,prefix=sddi-base-pr-,suffix=-{{sha}}
           labels: |
             maintainer=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.vendor=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.title=ckan-sddi-base-docker-dev
       -
-        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}
+        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}}
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -59,6 +62,7 @@ jobs:
       -
         name: Print image name
         run: |
+          echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}"
           echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}"
       -
         name: Extract metadata (tags, labels) for docker image
@@ -68,13 +72,16 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev
           tags: |
+            # Latest tag for PR, PR number only
+            type=ref,event=pr,prefix=sddi-base-pr-,suffix=-debug
+            # Tag for with commit sha appended
             type=ref,event=pr,prefix=sddi-base-pr-,suffix=-{{sha}}-debug
           labels: |
             maintainer=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.vendor=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.title=ckan-sddi-base-docker-dev-debug
       -
-        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}-debug
+        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-debug
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -88,6 +95,7 @@ jobs:
       -
         name: Print image name
         run: |
+          echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-debug"
           echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}-debug"
 
       # SDDI
@@ -99,13 +107,14 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev
           tags: |
+            type=ref,event=pr,prefix=sddi-pr-
             type=ref,event=pr,prefix=sddi-pr-,suffix=-{{sha}}
           labels: |
             maintainer=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.vendor=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.title=ckan-sddi-docker-dev
       -
-        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}
+        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -118,6 +127,7 @@ jobs:
       -
         name: Print image name
         run: |
+          echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}"
           echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}"
       -
         name: Extract metadata (tags, labels) for docker image
@@ -127,13 +137,14 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev
           tags: |
+            type=ref,event=pr,prefix=sddi-pr-,suffix=-debug
             type=ref,event=pr,prefix=sddi-pr-,suffix=-{{sha}}-debug
           labels: |
             maintainer=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.vendor=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.title=ckan-sddi-docker-dev-debug
       -
-        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}-debug
+        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-debug
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -147,6 +158,7 @@ jobs:
       -
         name: Print image name
         run: |
+          echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-debug"
           echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}-debug"
 
       # SDDI-SOCIAL
@@ -158,13 +170,14 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev
           tags: |
+            type=ref,event=pr,prefix=sddi-social-pr-
             type=ref,event=pr,prefix=sddi-social-pr-,suffix=-{{sha}}
           labels: |
             maintainer=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.vendor=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.title=ckan-sddi-social-docker-dev
       -
-        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}
+        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -177,6 +190,7 @@ jobs:
       -
         name: Print image name
         run: |
+          echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}"
           echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}"
       -
         name: Extract metadata (tags, labels) for docker image
@@ -186,13 +200,14 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev
           tags: |
+            type=ref,event=pr,prefix=sddi-social-pr-,suffix=-debug
             type=ref,event=pr,prefix=sddi-social-pr-,suffix=-{{sha}}-debug
           labels: |
             maintainer=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.vendor=Chair of Geoinformatics, Technical University of Munich (TUM)
             org.opencontainers.image.title=ckan-sddi-social-docker-dev-debug
       -
-        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}-debug
+        name: Build and publish ${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-debug
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -206,4 +221,5 @@ jobs:
       -
         name: Print image name
         run: |
+          echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-debug"
           echo "${{ env.REGISTRY }}/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-${{ steps.short-sha.outputs.sha }}-debug"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For releases `< 1.0.0` minor version steps may indicate breaking changes too.
 
 ## [1.2.0] - 2023-08-21
 
+### Added
+
+- Extended workflows to create a *latest* image for each pull request. The latest image will
+  be tagged following this pattern:
+
+  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}`
+  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-debug`
+  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}`
+  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-debug`
+  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}`
+  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-debug`
+
 ### Changed
 
 - Update to CKAN `2.9.9`

--- a/README.md
+++ b/README.md
@@ -133,18 +133,28 @@ Debug images are available starting from `v0.0.6`.
 > **Warning**: The debug image versions should not be used in a production environment!
 > With debug mode enabled, a visitor to your site could execute malicious commands.
 
-Furthermore, for each commit to a [Pull request](https://github.com/tum-gis/ckan-docker/pulls) all image flavors are build. These images are published in the
+Furthermore, for each commit to a [Pull request](https://github.com/tum-gis/ckan-docker/pulls) all image flavors are build.
+These images are published in the
 [`ckan-sddi-dev`](https://github.com/orgs/tum-gis/packages/container/package/ckan-sddi-dev)
 package. Images are named following this pattern:
 
+`ghcr.io/tum-gis/ckan-sddi-dev:<IMAGE FLAVOR>-pr-<PR NUMBER>-[-debug]`
 `ghcr.io/tum-gis/ckan-sddi-dev:<IMAGE FLAVOR>-pr-<PR NUMBER>-<SHORT-SHA>[-debug]`
+
+The image without the `SHORT-SHA` refer to the *latest* build of a pull request.
 
 For instance, for commit 19a2e64 to PR tum-gis/ckan-docker#26 following images are build:
 
+- `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-26`
+- `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-26-debug`
 - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-26-19a2e64`
 - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-26-19a2e64-debug`
+- `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-26`
+- `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-26-debug`
 - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-26-19a2e64`
 - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-26-19a2e64-debug`
+- `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-26`
+- `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-26-debug`
 - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-26-19a2e64`
 - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-26-19a2e64-debug`
 


### PR DESCRIPTION
Extended workflows to create a *latest* image for each pull request. The latest image will be tagged following this pattern:

  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}`
  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-base-pr-${{github.event.number}}-debug`
  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}`
  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-pr-${{github.event.number}}-debug`
  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}`
  - `ghcr.io/tum-gis/ckan-sddi-dev:sddi-social-pr-${{github.event.number}}-debug`